### PR TITLE
Use lodash where possible

### DIFF
--- a/lib/adapters/consul.js
+++ b/lib/adapters/consul.js
@@ -22,7 +22,7 @@ exports.initialize = function initialize(service, options, callback) {
 
 function Consul(options) {
     this.name = 'consul';
-    _.extend(internals.defaults, options);
+    _.assign(internals.defaults, options);
     internals.connection = ConsulLib(internals.defaults.connection);
 }
 

--- a/lib/adapters/consul.js
+++ b/lib/adapters/consul.js
@@ -2,7 +2,6 @@
 // Load modules
 var ConsulLib = require('consul');
 var _ = require('lodash');
-var path = require('doc-path');
 // Declare internals
 
 var internals = {};
@@ -58,7 +57,7 @@ Consul.prototype.getData = function getData(service, options, callback) {
 };
 
 
-internals.getAllKeys = function getAllKeys(keys,n, data, service, callback){
+internals.getAllKeys = function getAllKeys(keys, n, data, service, callback){
     if(n===keys.length){
         return callback(null, data);
     }
@@ -73,7 +72,7 @@ internals.getAllKeys = function getAllKeys(keys,n, data, service, callback){
         x = x.split("/").join(".");
 
 
-        path.setPath(data, x, key.Value);
+        _.set(data, x, key.Value);
 
 
         internals.getAllKeys(keys, n, data, service, callback);

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,7 +5,6 @@ var events = require('events');
 var fs = require('fs');
 var existsSync = fs.existsSync || path.existsSync;
 var _ = require('lodash');
-var path = require('doc-path');
 // Declare internals
 
 var internals = {
@@ -65,7 +64,7 @@ internals.ServiceConfig.prototype.start = function start( callback){
 };
 
 internals.ServiceConfig.prototype.get = function get(key){
-    return path.evaluatePath(internals.config, key);
+    return _.get(internals.config, key);
 };
 
 internals.ServiceConfig.prototype.getData = function getData(options, callback){

--- a/lib/index.js
+++ b/lib/index.js
@@ -22,7 +22,7 @@ exports = module.exports = internals.ServiceConfig = function (options) {
     var adapter;
     var serviceConfig = this;
 
-    _.extend(internals.options, options);
+    _.assign(internals.options, options);
 
     if (!options.service) {
         throw new Error('Options.service is required');

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
   "license": "ISC",
   "dependencies": {
     "consul": "^0.23.0",
-    "doc-path": "^1.0.7",
     "lodash": "^4.1.0"
   }
 }


### PR DESCRIPTION
- get rid-off `doc-path`, as `_.get()` / `_.set()` methods work the same way;
- use `_.assign()` instead of `_.extend()`. According to lodash [API docs](https://lodash.com/docs#assignIn)

> `_.extend` is an alias to `_.assignIn` which is like `_.assign` except that it iterates over own and inherited source properties.

I believe iterating over inherited properties is not what you want.
